### PR TITLE
Add cookbook to library

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,7 @@ group :development, :test do
   gem 'figaro'
   gem 'faraday'
   gem 'capybara'
+  gem 'launchy'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,8 @@ group :development, :test do
   gem 'faraday'
   gem 'capybara'
   gem 'launchy'
+  gem 'factory_bot_rails'
+  gem 'faker'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,13 @@ GEM
     diff-lcs (1.5.0)
     docile (1.4.0)
     erubi (1.12.0)
+    factory_bot (6.2.1)
+      activesupport (>= 5.0.0)
+    factory_bot_rails (6.2.0)
+      factory_bot (~> 6.2.0)
+      railties (>= 5.0.0)
+    faker (3.2.1)
+      i18n (>= 1.8.11, < 2)
     faraday (2.7.10)
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
@@ -294,6 +301,8 @@ DEPENDENCIES
   bootsnap
   capybara
   debug
+  factory_bot_rails
+  faker
   faraday
   figaro
   hirb

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,6 +116,8 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     jwt (2.7.1)
+    launchy (2.5.2)
+      addressable (~> 2.8)
     loofah (2.21.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -297,6 +299,7 @@ DEPENDENCIES
   hirb
   importmap-rails
   jbuilder
+  launchy
   omniauth-google-oauth2
   omniauth-rails_csrf_protection
   orderly

--- a/app/controllers/cookbooks_controller.rb
+++ b/app/controllers/cookbooks_controller.rb
@@ -1,18 +1,21 @@
 class CookbooksController <ApplicationController
   def new
     @user = User.find(params[:user_id])
-    binding.pry
+    if params["commit"]
+      @cookbook = Cookbook.new(cookbook_params)
+    end
   end
-
-  #between new and create there is a confirmation of info and a call to book api to find matches
 
   def create
     user = User.find(params[:user_id])
     cookbook = Cookbook.new(cookbook_params)
-    # binding.pry
     if cookbook.save
       redirect_to user_libraries_path
     end
+  end
+
+  def confirm
+
   end
 
   private

--- a/app/controllers/cookbooks_controller.rb
+++ b/app/controllers/cookbooks_controller.rb
@@ -1,0 +1,28 @@
+class CookbooksController <ApplicationController
+  def new
+    @user = User.find(params[:user_id])
+    binding.pry
+  end
+
+  #between new and create there is a confirmation of info and a call to book api to find matches
+
+  def create
+    user = User.find(params[:user_id])
+    cookbook = Cookbook.new(cookbook_params)
+    # binding.pry
+    if cookbook.save
+      redirect_to user_libraries_path
+    end
+  end
+
+  private
+
+  def cookbook_params
+    params.permit(:title,
+                  :author,
+                  :publisher,
+                  :country_cuisine,
+                  :isbn,
+                  :library_id)
+  end
+end

--- a/app/controllers/libraries_controller.rb
+++ b/app/controllers/libraries_controller.rb
@@ -1,5 +1,6 @@
 class LibrariesController < ApplicationController
   def index
     @user = User.find(params[:user_id])
+    @cookbooks = @user.library.cookbooks
   end
 end

--- a/app/models/cookbook.rb
+++ b/app/models/cookbook.rb
@@ -1,5 +1,5 @@
 class Cookbook < ApplicationRecord
-  validates_presence_of :name, :isbn, :author, :publisher
+  validates_presence_of :title, :isbn, :author, :publisher
   
   belongs_to :library
   has_many :recipes, dependent: :destroy

--- a/app/models/cookbook.rb
+++ b/app/models/cookbook.rb
@@ -1,5 +1,5 @@
 class Cookbook < ApplicationRecord
-  validates_presence_of :title, :isbn, :author, :publisher
+  validates_presence_of :title, :author, :publisher
   
   belongs_to :library
   has_many :recipes, dependent: :destroy

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -1,4 +1,8 @@
 class Recipe < ApplicationRecord
+  enum meal_time: {breakfast: 0, brunch: 1, lunch: 2, dinner: 3}
+  enum meal_type: {appetizer: 0, salad: 1, entree: 2, dessert: 3, drink: 4}
+  enum food_group: {grain: 0, protein: 1, fruit_vegetables: 2, dairy: 3}
+  
   validates_presence_of :name, :meal_time, :meal_type, :food_group, :country_of_origin, :page
 
   belongs_to :cookbook

--- a/app/views/cookbooks/new.html.erb
+++ b/app/views/cookbooks/new.html.erb
@@ -1,17 +1,41 @@
-<center><h1> Add a New Cookbook </h1></center>
 
-<section id="cookbook_form">
-  <%= form_with url: user_library_cookbooks_path(@user.id, @user.library.id), method: :post do |form| %>
-    <%= form.label :title, "Title:" %>
-    <p><%= form.text_field :title %></p>
-    <%= form.label :author, "Author:" %>
-    <p><%= form.text_field :author%></p>
-    <%= form.label :publisher, "Publisher:" %>
-    <p><%= form.text_field :publisher%></p>
-    <%= form.label :isbn, "ISBN:" %>
-    <p><%= form.text_field :isbn%></p>
-    <%= form.label :country_cuisine, "Nation of Origin:" %>
-    <p><%= form.text_field :country_cuisine%></p>
-    <%= form.submit "Submit" %>
-  <% end %>
-</section>
+<% if @cookbook %>
+  <center><h1> Is this your cookbook? </h1></center> 
+  <section id="user_entries">
+    <p>Title: <%= @cookbook.title %></p>
+    <p>Author: <%= @cookbook.author %></p>
+    <p>Publisher: <%= @cookbook.publisher %></p>
+    <p>ISBN: <%= @cookbook.isbn %></p>
+    <p>Nation of Origin: <%= @cookbook.country_cuisine %></p>
+  </section>
+
+  <section id="cookbook_match">
+    <%= form_with url: user_library_cookbooks_path(@user.id, @user.library.id), method: :post do |form| %>
+      <%= form.radio_button :user_entry, true %>
+      <%= form.label :user_entry, "None of the books above match, record by cookbook as entered." %>
+      <%= form.hidden_field :title, value: @cookbook.title %>
+      <%= form.hidden_field :author, value: @cookbook.author %>
+      <%= form.hidden_field :publisher, value: @cookbook.publisher%>
+      <%= form.hidden_field :country_cuisine, value: @cookbook.country_cuisine %>
+      <%= form.submit "Save" %>
+    <% end %>
+  </section>
+<% else %>
+  <center><h1> Add a New Cookbook </h1></center>
+
+  <section id="cookbook_form">
+    <%= form_with url: new_user_library_cookbook_path(@user.id, @user.library.id), method: :get do |form| %>
+      <%= form.label :title, "Title:" %>
+      <p><%= form.text_field :title %></p>
+      <%= form.label :author, "Author:" %>
+      <p><%= form.text_field :author%></p>
+      <%= form.label :publisher, "Publisher:" %>
+      <p><%= form.text_field :publisher%></p>
+      <%= form.label :isbn, "ISBN:" %>
+      <p><%= form.text_field :isbn%></p>
+      <%= form.label :country_cuisine, "Nation of Origin:" %>
+      <p><%= form.text_field :country_cuisine%></p>
+      <%= form.submit "Submit" %>
+    <% end %>
+  </section>
+<% end %>

--- a/app/views/cookbooks/new.html.erb
+++ b/app/views/cookbooks/new.html.erb
@@ -1,0 +1,17 @@
+<center><h1> Add a New Cookbook </h1></center>
+
+<section id="cookbook_form">
+  <%= form_with url: user_library_cookbooks_path(@user.id, @user.library.id), method: :post do |form| %>
+    <%= form.label :title, "Title:" %>
+    <p><%= form.text_field :title %></p>
+    <%= form.label :author, "Author:" %>
+    <p><%= form.text_field :author%></p>
+    <%= form.label :publisher, "Publisher:" %>
+    <p><%= form.text_field :publisher%></p>
+    <%= form.label :isbn, "ISBN:" %>
+    <p><%= form.text_field :isbn%></p>
+    <%= form.label :country_cuisine, "Nation of Origin:" %>
+    <p><%= form.text_field :country_cuisine%></p>
+    <%= form.submit "Submit" %>
+  <% end %>
+</section>

--- a/app/views/libraries/index.html.erb
+++ b/app/views/libraries/index.html.erb
@@ -1,3 +1,7 @@
 <center><h1> <%= @user.first_name %>'s Library </h1></center>
 
 <h3><%= link_to 'Add a cookbook to my library', new_user_library_cookbook_path(@user.id, @user.library.id) %></h3>
+
+<% @cookbooks.each do |cookbook| %>
+  <p><%= cookbook.title %> by <%= cookbook.author %></p>
+<% end %>

--- a/app/views/libraries/index.html.erb
+++ b/app/views/libraries/index.html.erb
@@ -1,1 +1,3 @@
 <center><h1> <%= @user.first_name %>'s Library </h1></center>
+
+<h3><%= link_to 'Add a cookbook to my library', new_user_library_cookbook_path(@user.id, @user.library.id) %></h3>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,8 @@ Rails.application.routes.draw do
 
   resources :sign_in, only: [:index]
   resources :users, only: [:index, :create] do
-    resources :libraries, only: [:index]
+    resources :libraries, only: [:index] do
+      resources :cookbooks, only: [:new, :create] #is this too long of a route?
+    end
   end
 end

--- a/db/migrate/20230928013914_change_name_in_cookbooks.rb
+++ b/db/migrate/20230928013914_change_name_in_cookbooks.rb
@@ -1,0 +1,5 @@
+class ChangeNameInCookbooks < ActiveRecord::Migration[7.0]
+  def change
+    rename_column(:cookbooks, :name, :title)
+  end
+end

--- a/db/migrate/20230928014419_change_columns_in_recipes_to_enum.rb
+++ b/db/migrate/20230928014419_change_columns_in_recipes_to_enum.rb
@@ -1,0 +1,11 @@
+class ChangeColumnsInRecipesToEnum < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :recipes, :meal_time, :meal_times_del
+    rename_column :recipes, :meal_type, :meal_types_del
+    rename_column :recipes, :food_group, :food_group_del
+
+    add_column :recipes, :meal_time, :integer
+    add_column :recipes, :meal_type, :integer
+    add_column :recipes, :food_group, :integer
+  end
+end

--- a/db/migrate/20230928015846_remove_columns_from_recipes.rb
+++ b/db/migrate/20230928015846_remove_columns_from_recipes.rb
@@ -1,0 +1,5 @@
+class RemoveColumnsFromRecipes < ActiveRecord::Migration[7.0]
+  def change
+    remove_columns(:recipes, :meal_times_del, :meal_types_del, :food_group_del)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_01_190618) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_28_013914) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "cookbooks", force: :cascade do |t|
-    t.string "name"
+    t.string "title"
     t.string "isbn"
     t.string "author"
     t.string "publisher"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_28_013914) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_28_015846) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -54,14 +54,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_28_013914) do
 
   create_table "recipes", force: :cascade do |t|
     t.string "name"
-    t.string "meal_time"
-    t.string "meal_type"
-    t.string "food_group"
     t.string "country_of_origin"
     t.integer "page"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "cookbook_id", null: false
+    t.integer "meal_time"
+    t.integer "meal_type"
+    t.integer "food_group"
     t.index ["cookbook_id"], name: "index_recipes_on_cookbook_id"
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -25,13 +25,61 @@ FactoryBot.define do
     association :library
   end
 
-  # factory :recipes do
-  #   name {Faker::Food.dish}
-  #   enum meal_time: {breakfast: 0, brunch: 1, lunch: 2, dinner: 3}
-  #   enum meal_type: {appetizer: 0, salad: 1, entree: 2, dessert: 3, drink: 4}
-  #   enum food_group: {grain: 0, protein: 1, fruit_vegetables: 2, dairy: 3}
-  #   country_of_origin {Faker::Nation.nationality}
-  #   page {Faker::Number.between(from: 10, to: 500)}
-  #   association :cookbook
-  # end
+  factory :recipes do
+    name {Faker::Food.dish}
+    country_of_origin {Faker::Nation.nationality}
+    page {Faker::Number.between(from: 10, to: 500)}
+
+    trait :breakfast do
+      meal_time {:breakfast}
+    end
+
+    trait :brunch do
+      meal_time {:brunch}
+    end
+
+    trait :lunch do
+      meal_time {:lunch}
+    end
+
+    trait :dinner do
+      meal_time {:dinner}
+    end
+
+    trait :appetizer do
+      meal_type {:appetizer}
+    end
+
+    trait :salad do
+      meal_type {:salad}
+    end
+    
+    trait :entree do
+      meal_type {:entree}
+    end
+
+    trait :dessert do
+      meal_type {:dessert}
+    end
+
+    trait :drink do
+      meal_type {:drink}
+    end
+
+    trait :grain do
+      food_group {:grain}
+    end
+
+    trait :protein do
+      food_group {:protein}
+    end
+    trait :fruit_vegetables do
+      food_group {:fruit_vegetables}
+    end
+    trait :dairy do
+      food_group {:dairy}
+    end
+
+    association :cookbook
+  end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     last_name {Faker::Name.last_name}
     email {"#{first_name}.#{last_name}@example.com".downcase}
     google_id {Faker::Number.number(digits: 12)}
-    googke_token {Faker::Alphanumeric.alpha(number:15)}
+    google_token {Faker::Alphanumeric.alpha(number:15)}
     profile_picture {"picture.picture.com"}
     
     trait :google do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -6,7 +6,10 @@ FactoryBot.define do
     google_id {Faker::Number.number(digits: 12)}
     googke_token {Faker::Alphanumeric.alpha(number:15)}
     profile_picture {"picture.picture.com"}
-    enum oauth_provider: {google: 0} 
+    
+    trait :google do
+      oauth_provider {:google}
+    end
   end
 
   factory :library do
@@ -22,13 +25,13 @@ FactoryBot.define do
     association :library
   end
 
-  factory :recipes do
-    name {Faker::Food.dish}
-    enum meal_time: {breakfast: 0, brunch: 1, lunch: 2, dinner: 3}
-    enum meal_type: {appetizer: 0, salad: 1, entree: 2, dessert: 3, drink: 4}
-    enum food_group: {grain: 0, protein: 1, fruit_vegetables: 2, dairy: 3}
-    country_of_origin {Faker::Nation.nationality}
-    page {Faker::Number.between(from: 10, to: 500)}
-    association :cookbook
-  end
+  # factory :recipes do
+  #   name {Faker::Food.dish}
+  #   enum meal_time: {breakfast: 0, brunch: 1, lunch: 2, dinner: 3}
+  #   enum meal_type: {appetizer: 0, salad: 1, entree: 2, dessert: 3, drink: 4}
+  #   enum food_group: {grain: 0, protein: 1, fruit_vegetables: 2, dairy: 3}
+  #   country_of_origin {Faker::Nation.nationality}
+  #   page {Faker::Number.between(from: 10, to: 500)}
+  #   association :cookbook
+  # end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,0 +1,34 @@
+FactoryBot.define do
+  factory :user do
+    first_name {Faker::Name.first_name}
+    last_name {Faker::Name.last_name}
+    email {"#{first_name}.#{last_name}@example.com".downcase}
+    google_id {Faker::Number.number(digits: 12)}
+    googke_token {Faker::Alphanumeric.alpha(number:15)}
+    profile_picture {"picture.picture.com"}
+    enum oauth_provider: {google: 0} 
+  end
+
+  factory :library do
+    association :user
+  end
+
+  factory :cookbook do
+    title {Faker::Book.title}
+    isbn {Faker::Barcode.isbn}
+    author {Faker::Book.author}
+    publisher {Faker::Book.publisher}
+    country_cuisine {Faker::Nation.nationality}
+    association :library
+  end
+
+  factory :recipes do
+    name {Faker::Food.dish}
+    enum meal_time: {breakfast: 0, brunch: 1, lunch: 2, dinner: 3}
+    enum meal_type: {appetizer: 0, salad: 1, entree: 2, dessert: 3, drink: 4}
+    enum food_group: {grain: 0, protein: 1, fruit_vegetables: 2, dairy: 3}
+    country_of_origin {Faker::Nation.nationality}
+    page {Faker::Number.between(from: 10, to: 500)}
+    association :cookbook
+  end
+end

--- a/spec/features/cookbooks/new_spec.rb
+++ b/spec/features/cookbooks/new_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe "New Cookbook form page" do
     end
   end
 
-  it 'can fill out and submit the form and page is redirected to matches/confirmation page' do
+  it 'can fill out and submit the form then page is redirected to the same page but with matches/confirmation options
+      after clicking save, the cookbook is created and the user is redirected to the library and they can see their book listed' do
     title = Faker::Book.title
     author = Faker::Book.author
     publisher = Faker::Book.publisher
@@ -34,10 +35,10 @@ RSpec.describe "New Cookbook form page" do
       fill_in :isbn, with: isbn
       click_button 'Submit'
     end
-    save_and_open_page
-    expect(path).to eq(new_user_library_cookbook_path(@user.id, @library.id))
     
-    within ("#entries") do
+    expect(current_path).to eq(new_user_library_cookbook_path(@user.id, @library.id))
+    
+    within ("#user_entries") do
       expect(page).to have_content("Title: #{title}")
       expect(page).to have_content("Author: #{author}")
       expect(page).to have_content("Publisher: #{publisher}")
@@ -45,10 +46,15 @@ RSpec.describe "New Cookbook form page" do
       expect(page).to have_content("Nation of Origin: #{country_cuisine}")
     end
 
-      expect(page).to not_have_field(:title)
-      expect(page).to not_have_field(:author)
-      expect(page).to not_have_field(:publisher)
-      expect(page).to not_have_field(:country_cuisine)
+      expect(page).to_not have_field(:title)
+      expect(page).to_not have_field(:author)
+      expect(page).to_not have_field(:publisher)
+      expect(page).to_not have_field(:country_cuisine)
+
+    click_button "Save"
+    expect(current_path).to eq(user_libraries_path(@user.id))
+
+    expect(page).to have_content("#{title} by #{author}")
   end
 
   # it 'will show an error if a form is submitted without a title'

--- a/spec/features/cookbooks/new_spec.rb
+++ b/spec/features/cookbooks/new_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe "New Cookbook form page" do
+  before :each do
+    @user = create(:user, :google)
+    @library = @user.create_library
+  end
+
+  it "has the fields for adding a new cookbook" do
+    visit new_user_library_cookbook_path(@user.id, @library.id)
+    
+    expect(page).to have_content("Add a New Cookbook")
+    within ("#cookbook_form") do
+      expect(page).to have_field(:title)
+      expect(page).to have_field(:author)
+      expect(page).to have_field(:publisher)
+      expect(page).to have_field(:country_cuisine)
+    end
+  end
+
+  it 'can fill out and submit the form and page is redirected to matches/confirmation page' do
+    title = Faker::Book.title
+    author = Faker::Book.author
+    publisher = Faker::Book.publisher
+    country_cuisine = Faker::Nation.nationality
+    isbn = Faker::Barcode.isbn
+
+    visit new_user_library_cookbook_path(@user.id, @library.id)
+    within ("#cookbook_form") do
+      fill_in :title, with: title
+      fill_in :author, with: author
+      fill_in :publisher, with: publisher
+      fill_in :country_cuisine, with: country_cuisine
+      fill_in :isbn, with: isbn
+      click_button 'Submit'
+    end
+    save_and_open_page
+    expect(path).to eq(new_user_library_cookbook_path(@user.id, @library.id))
+    
+    within ("#entries") do
+      expect(page).to have_content("Title: #{title}")
+      expect(page).to have_content("Author: #{author}")
+      expect(page).to have_content("Publisher: #{publisher}")
+      expect(page).to have_content("ISBN: #{isbn}")
+      expect(page).to have_content("Nation of Origin: #{country_cuisine}")
+    end
+
+      expect(page).to not_have_field(:title)
+      expect(page).to not_have_field(:author)
+      expect(page).to not_have_field(:publisher)
+      expect(page).to not_have_field(:country_cuisine)
+  end
+
+  # it 'will show an error if a form is submitted without a title'
+
+end

--- a/spec/features/libraries/index_spec.rb
+++ b/spec/features/libraries/index_spec.rb
@@ -12,5 +12,12 @@ RSpec.describe 'library index' do
    
       expect(page).to have_content("#{@user.first_name}'s Library")
     end
+
+    it 'shows a button to add a cookbook' do
+      visit user_libraries_path(@user.id)
+      save_and_open_page
+
+      expect(page).to have_link("Add a cookbook to my library", href: new_user_library_cookbook_path(@user.id, @library.id))
+    end
   end
 end

--- a/spec/features/libraries/index_spec.rb
+++ b/spec/features/libraries/index_spec.rb
@@ -15,9 +15,24 @@ RSpec.describe 'library index' do
 
     it 'shows a button to add a cookbook' do
       visit user_libraries_path(@user.id)
-      save_and_open_page
 
       expect(page).to have_link("Add a cookbook to my library", href: new_user_library_cookbook_path(@user.id, @library.id))
+    end
+
+    it 'shows books in my library' do
+      book1 = create(:cookbook, library: @library)
+      book2 = create(:cookbook, library: @library)
+      book3 = create(:cookbook, library: @library)
+      book4 = create(:cookbook, library: @library)
+      book5 = create(:cookbook, library: @library)
+
+      visit user_libraries_path(@user.id)
+
+      expect(page).to have_content("#{book1.title} by #{book1.author}")
+      expect(page).to have_content("#{book2.title} by #{book2.author}")
+      expect(page).to have_content("#{book3.title} by #{book3.author}")
+      expect(page).to have_content("#{book4.title} by #{book4.author}")
+      expect(page).to have_content("#{book5.title} by #{book5.author}")
     end
   end
 end

--- a/spec/models/cookbook_spec.rb
+++ b/spec/models/cookbook_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 RSpec.describe Cookbook, type: :model do
   describe 'validations' do
     it {should validate_presence_of :title}
-    it {should validate_presence_of :isbn}
     it {should validate_presence_of :author}
     it {should validate_presence_of :publisher}
   end

--- a/spec/models/cookbook_spec.rb
+++ b/spec/models/cookbook_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Cookbook, type: :model do
   describe 'validations' do
-    it {should validate_presence_of :name}
+    it {should validate_presence_of :title}
     it {should validate_presence_of :isbn}
     it {should validate_presence_of :author}
     it {should validate_presence_of :publisher}

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,3 +1,4 @@
+require '/support/factory_bot.rb'
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,4 +1,4 @@
-require '/support/factory_bot.rb'
+require 'support/factory_bot.rb'
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,5 @@
+require 'factory_bot'
+
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+end


### PR DESCRIPTION
This PR adds:

1. Views for adding a new cookbook with an 'add cookbook' form to the user's library.
2. Adjusts the recipes table to use an enum for meal_time, meal_type, and food_group
3. Adds gems launchy, faker, and factory bot