### PR TITLE
Add cookbook to library

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -41,10 +41,10 @@ jobs:
       - name: Install Chrome and ChromeDriver
         run: |
           wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-          sudo dpkg -i google-chrome-stable_current_amd64.deb
+          sudo apt install ./google-chrome-stable_current_amd64.deb
           wget "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/118.0.5993.70/linux64/chromedriver-linux64.zip"
-          unzip chromedriver_linux64.zip
-          sudo mv chromedriver /usr/local/bin/
+          unzip chromedriver-linux64.zip
+          sudo mv chromedriver-linux64/chromedriver /usr/local/bin/
           sudo chmod +x /usr/local/bin/chromedriver
       - name: Run tests
         run: bundle exec rspec

--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -42,8 +42,7 @@ jobs:
         run: |
           wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
           sudo dpkg -i google-chrome-stable_current_amd64.deb
-          LATEST_CHROMEDRIVER_VERSION=$(curl -s "https://chromedriver.storage.googleapis.com/LATEST_RELEASE")
-          wget "https://chromedriver.storage.googleapis.com/${LATEST_CHROMEDRIVER_VERSION}/chromedriver_linux64.zip"
+          wget "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/118.0.5993.70/linux64/chrome-linux64.zip"
           unzip chromedriver_linux64.zip
           sudo mv chromedriver /usr/local/bin/
           sudo chmod +x /usr/local/bin/chromedriver

--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -43,7 +43,7 @@ jobs:
           wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
           sudo dpkg -i google-chrome-stable_current_amd64.deb
           wget "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/118.0.5993.70/linux64/chrome-linux64.zip"
-          unzip chromedriver_linux64.zip
+          unzip chrome-linux64.zip
           sudo mv chromedriver /usr/local/bin/
           sudo chmod +x /usr/local/bin/chromedriver
       - name: Run tests

--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -42,8 +42,8 @@ jobs:
         run: |
           wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
           sudo dpkg -i google-chrome-stable_current_amd64.deb
-          wget "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/118.0.5993.70/linux64/chrome-linux64.zip"
-          unzip chrome-linux64.zip
+          wget "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/118.0.5993.70/linux64/chromedriver-linux64.zip"
+          unzip chromedriver_linux64.zip
           sudo mv chromedriver /usr/local/bin/
           sudo chmod +x /usr/local/bin/chromedriver
       - name: Run tests

--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -38,5 +38,14 @@ jobs:
       - name: Set up database schema
         run: bin/rails db:schema:load
       # Add or replace test runners here
+      - name: Install Chrome and ChromeDriver
+        run: |
+          wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+          sudo dpkg -i google-chrome-stable_current_amd64.deb
+          LATEST_CHROMEDRIVER_VERSION=$(curl -s "https://chromedriver.storage.googleapis.com/LATEST_RELEASE")
+          wget "https://chromedriver.storage.googleapis.com/${LATEST_CHROMEDRIVER_VERSION}/chromedriver_linux64.zip"
+          unzip chromedriver_linux64.zip
+          sudo mv chromedriver /usr/local/bin/
+          sudo chmod +x /usr/local/bin/chromedriver
       - name: Run tests
         run: bundle exec rspec

--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ group :development, :test do
   gem 'launchy'
   gem 'factory_bot_rails'
   gem 'faker'
+  gem 'capybara_table'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,7 @@ group :development, :test do
   gem 'factory_bot_rails'
   gem 'faker'
   gem 'capybara_table'
+  gem 'selenium-webdriver'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,10 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    capybara_table (0.3.0)
+      capybara (>= 3.31)
+      terminal-table
+      xpath (>= 2.1)
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
     crack (0.4.5)
@@ -268,6 +272,8 @@ GEM
       sprockets (>= 3.0.0)
     stimulus-rails (1.2.2)
       railties (>= 6.0.0)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
     thor (1.2.2)
     timeout (0.4.0)
     turbo-rails (1.4.0)
@@ -276,6 +282,7 @@ GEM
       railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    unicode-display_width (2.5.0)
     version_gem (1.1.3)
     web-console (4.2.0)
       actionview (>= 6.0.0)
@@ -300,6 +307,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   capybara
+  capybara_table
   debug
   factory_bot_rails
   faker

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -252,6 +252,11 @@ GEM
       rspec-support (~> 3.12)
     rspec-support (3.12.1)
     ruby2_keywords (0.0.5)
+    rubyzip (2.3.2)
+    selenium-webdriver (4.14.0)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
     shoulda-matchers (5.3.0)
       activesupport (>= 5.2.0)
     simplecov (0.22.0)
@@ -293,6 +298,7 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
+    websocket (1.2.10)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -326,6 +332,7 @@ DEPENDENCIES
   rails (~> 7.0.7)
   redis (~> 4.0)
   rspec-rails (~> 6.0.0)
+  selenium-webdriver
   shoulda-matchers (~> 5.0)
   simplecov
   sprockets-rails

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -2,3 +2,4 @@
 //= link_directory ../stylesheets .css
 //= link_tree ../../javascript .js
 //= link_tree ../../../vendor/javascript .js
+//= link save_button.js

--- a/app/assets/javascripts/save_button.js
+++ b/app/assets/javascripts/save_button.js
@@ -1,0 +1,11 @@
+  $(document).ready(function() {
+    $('input[type=radio]').change(function() {
+      if ($('input[type=radio]:checked').length > 0) {
+        $('#save_button').prop('disabled', false);
+        $(console).log("disabled");
+      } else {
+        $('#save_button').prop('disabled', true);
+        $(console).log("enabled");
+      }
+    });
+  });

--- a/app/controllers/cookbooks_controller.rb
+++ b/app/controllers/cookbooks_controller.rb
@@ -22,6 +22,9 @@ class CookbooksController <ApplicationController
     cookbook = Cookbook.new(cookbook_params)
     if cookbook.save
       redirect_to user_libraries_path
+    else
+      flash.alert = "Something went wrong. Please re-enter your cookbook's details."
+      render :new
     end
   end
 

--- a/app/controllers/cookbooks_controller.rb
+++ b/app/controllers/cookbooks_controller.rb
@@ -2,10 +2,11 @@ class CookbooksController <ApplicationController
   def new
     @user = User.find(params[:user_id])
     @cookbook = Cookbook.new
-    if params[:title] == ""
+    
+    if params[:cookbook] && params[:cookbook][:title].blank?
       redirect_to(new_user_library_cookbook_path(@user.id, @user.library.id))
       flash.alert = "Please enter a title for your cookbook."
-    elsif params["commit"]
+    elsif params[:commit] && params[:cookbook] 
       @cookbook_check = Cookbook.new(cookbook_params)
     end
   end

--- a/app/controllers/cookbooks_controller.rb
+++ b/app/controllers/cookbooks_controller.rb
@@ -1,8 +1,12 @@
 class CookbooksController <ApplicationController
   def new
     @user = User.find(params[:user_id])
-    if params["commit"]
-      @cookbook = Cookbook.new(cookbook_params)
+    @cookbook = Cookbook.new
+    if params[:title] == ""
+      redirect_to(new_user_library_cookbook_path(@user.id, @user.library.id))
+      flash.alert = "Please enter a title for your cookbook."
+    elsif params["commit"]
+      @cookbook_check = Cookbook.new(cookbook_params)
     end
   end
 
@@ -17,7 +21,7 @@ class CookbooksController <ApplicationController
   private
 
   def cookbook_params
-    params.permit(:title,
+    params.require(:cookbook).permit(:title,
                   :author,
                   :publisher,
                   :country_cuisine,

--- a/app/controllers/cookbooks_controller.rb
+++ b/app/controllers/cookbooks_controller.rb
@@ -2,13 +2,16 @@ class CookbooksController <ApplicationController
   def new
     @user = User.find(params[:user_id])
     @cookbook = Cookbook.new
-    
+  end
+
+  def match
+    @user = User.find(params[:user_id])
     if params[:cookbook] && params[:cookbook][:title].blank?
-      redirect_to(new_user_library_cookbook_path(@user.id, @user.library.id))
+      binding.pry
+      redirect_to new_user_library_cookbook_path(@user.id, @user.library.id)
       flash.alert = "Please enter a title for your cookbook."
-    elsif params[:commit] && params[:cookbook] 
-      @cookbook_check = Cookbook.new(cookbook_params)
     end
+    @cookbook = Cookbook.new(cookbook_params)
   end
 
   def create

--- a/app/controllers/cookbooks_controller.rb
+++ b/app/controllers/cookbooks_controller.rb
@@ -14,10 +14,6 @@ class CookbooksController <ApplicationController
     end
   end
 
-  def confirm
-
-  end
-
   private
 
   def cookbook_params

--- a/app/controllers/cookbooks_controller.rb
+++ b/app/controllers/cookbooks_controller.rb
@@ -1,14 +1,17 @@
 class CookbooksController <ApplicationController
   def new
     @user = User.find(params[:user_id])
-    @cookbook = Cookbook.new
+    if params[:cookbook]
+      @cookbook = Cookbook.new(cookbook_params)
+    else
+      @cookbook = Cookbook.new
+    end
   end
 
   def match
     @user = User.find(params[:user_id])
     if params[:cookbook] && params[:cookbook][:title].blank?
-      binding.pry
-      redirect_to new_user_library_cookbook_path(@user.id, @user.library.id)
+      redirect_to new_user_library_cookbook_path(@user.id, @user.library.id, cookbook: cookbook_params)
       flash.alert = "Please enter a title for your cookbook."
     end
     @cookbook = Cookbook.new(cookbook_params)

--- a/app/models/cookbook.rb
+++ b/app/models/cookbook.rb
@@ -1,5 +1,5 @@
 class Cookbook < ApplicationRecord
-  validates_presence_of :title, :author, :publisher
+  validates_presence_of :title
   
   belongs_to :library
   has_many :recipes, dependent: :destroy

--- a/app/views/cookbooks/match.html.erb
+++ b/app/views/cookbooks/match.html.erb
@@ -25,6 +25,7 @@
         <%= form.hidden_field :library_id, value: @user.library.id %>
         <%= form.submit "Save", disabled: true, id: "save_button" %>
       <% end %>
+      <%= button_to "Cancel", user_libraries_path(@user.id), method: :get %>
     </section>
     <%= javascript_include_tag 'save_button' %>
 </body>

--- a/app/views/cookbooks/match.html.erb
+++ b/app/views/cookbooks/match.html.erb
@@ -1,0 +1,21 @@
+<center><h1> Is this your cookbook? </h1></center> 
+  <section id="user_entries">
+    <p>Title: <%= @cookbook.title %></p>
+    <p>Author: <%= @cookbook.author %></p>
+    <p>Publisher: <%= @cookbook.publisher %></p>
+    <p>ISBN: <%= @cookbook.isbn %></p>
+    <p>Nation of Origin: <%= @cookbook.country_cuisine %></p>
+  </section>
+
+  <section id="cookbook_match">
+    <%= form_with model: @cookbook, url: user_library_cookbooks_path(@user.id, @user.library.id), method: :post do |form| %>
+      <%= form.radio_button :user_entry, true %>
+      <%= form.label :user_entry_true, "None of the books above match, record by cookbook as entered." %>
+      <%= form.hidden_field :title, value: @cookbook.title %>
+      <%= form.hidden_field :author, value: @cookbook.author %>
+      <%= form.hidden_field :publisher, value: @cookbook.publisher%>
+      <%= form.hidden_field :country_cuisine, value: @cookbook.country_cuisine %>
+      <%= form.hidden_field :library_id, value: @user.library.id %>
+      <%= form.submit "Save" %>
+    <% end %>
+  </section>

--- a/app/views/cookbooks/match.html.erb
+++ b/app/views/cookbooks/match.html.erb
@@ -16,6 +16,6 @@
       <%= form.hidden_field :publisher, value: @cookbook.publisher%>
       <%= form.hidden_field :country_cuisine, value: @cookbook.country_cuisine %>
       <%= form.hidden_field :library_id, value: @user.library.id %>
-      <%= form.submit "Save" %>
+      <%= form.submit "Save", id: "save_button" %>
     <% end %>
   </section>

--- a/app/views/cookbooks/match.html.erb
+++ b/app/views/cookbooks/match.html.erb
@@ -1,21 +1,31 @@
-<center><h1> Is this your cookbook? </h1></center> 
-  <section id="user_entries">
-    <p>Title: <%= @cookbook.title %></p>
-    <p>Author: <%= @cookbook.author %></p>
-    <p>Publisher: <%= @cookbook.publisher %></p>
-    <p>ISBN: <%= @cookbook.isbn %></p>
-    <p>Nation of Origin: <%= @cookbook.country_cuisine %></p>
-  </section>
+<!DOCTYPE html>
+<html>
+<head>
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+</head>
 
-  <section id="cookbook_match">
-    <%= form_with model: @cookbook, url: user_library_cookbooks_path(@user.id, @user.library.id), method: :post do |form| %>
-      <%= form.radio_button :user_entry, true %>
-      <%= form.label :user_entry_true, "None of the books above match, record by cookbook as entered." %>
-      <%= form.hidden_field :title, value: @cookbook.title %>
-      <%= form.hidden_field :author, value: @cookbook.author %>
-      <%= form.hidden_field :publisher, value: @cookbook.publisher%>
-      <%= form.hidden_field :country_cuisine, value: @cookbook.country_cuisine %>
-      <%= form.hidden_field :library_id, value: @user.library.id %>
-      <%= form.submit "Save", id: "save_button" %>
-    <% end %>
-  </section>
+<body>
+  <center><h1> Is this your cookbook? </h1></center> 
+    <section id="user_entries">
+      <p>Title: <%= @cookbook.title %></p>
+      <p>Author: <%= @cookbook.author %></p>
+      <p>Publisher: <%= @cookbook.publisher %></p>
+      <p>ISBN: <%= @cookbook.isbn %></p>
+      <p>Nation of Origin: <%= @cookbook.country_cuisine %></p>
+    </section>
+
+    <section id="cookbook_match">
+      <%= form_with model: @cookbook, url: user_library_cookbooks_path(@user.id, @user.library.id), method: :post do |form| %>
+        <%= form.radio_button :user_entry, true %>
+        <%= form.label :user_entry_true, "None of the books above match, record by cookbook as entered." %>
+        <%= form.hidden_field :title, value: @cookbook.title %>
+        <%= form.hidden_field :author, value: @cookbook.author %>
+        <%= form.hidden_field :publisher, value: @cookbook.publisher%>
+        <%= form.hidden_field :country_cuisine, value: @cookbook.country_cuisine %>
+        <%= form.hidden_field :library_id, value: @user.library.id %>
+        <%= form.submit "Save", disabled: true, id: "save_button" %>
+      <% end %>
+    </section>
+    <%= javascript_include_tag 'save_button' %>
+</body>
+</html>

--- a/app/views/cookbooks/new.html.erb
+++ b/app/views/cookbooks/new.html.erb
@@ -1,42 +1,17 @@
-
-<% if @cookbook_check %>
-  <center><h1> Is this your cookbook? </h1></center> 
-  <section id="user_entries">
-    <p>Title: <%= @cookbook_check.title %></p>
-    <p>Author: <%= @cookbook_check.author %></p>
-    <p>Publisher: <%= @cookbook_check.publisher %></p>
-    <p>ISBN: <%= @cookbook_check.isbn %></p>
-    <p>Nation of Origin: <%= @cookbook_check.country_cuisine %></p>
-  </section>
-
-  <section id="cookbook_match">
-    <%= form_with model: @cookbook, url: user_library_cookbooks_path(@user.id, @user.library.id), method: :post do |form| %>
-      <%= form.radio_button :user_entry, true %>
-      <%= form.label :user_entry_true, "None of the books above match, record by cookbook as entered." %>
-      <%= form.hidden_field :title, value: @cookbook_check.title %>
-      <%= form.hidden_field :author, value: @cookbook_check.author %>
-      <%= form.hidden_field :publisher, value: @cookbook_check.publisher%>
-      <%= form.hidden_field :country_cuisine, value: @cookbook_check.country_cuisine %>
-      <%= form.hidden_field :library_id, value: @user.library.id %>
-      <%= form.submit "Save" %>
-    <% end %>
-  </section>
-<% else %>
-  <center><h1> Add a New Cookbook </h1></center>
-
+<center><h1> Add a New Cookbook </h1></center>
   <section id="cookbook_form">
-    <%= form_with model: @cookbook, url: new_user_library_cookbook_path(@user.id, @user.library.id), method: :get do |form| %>
+    <%= form_with model: @cookbook, url: match_new_user_library_cookbook_path(@user.id, @user.library.id), method: :get do |form| %>
       <%= form.label :title, "Title:" %>
       <p><%= form.text_field :title %></p>
       <%= form.label :author, "Author:" %>
-      <p><%= form.text_field :author%></p>
+      <p><%= form.text_field :author, value: @cookbook.author %></p>
       <%= form.label :publisher, "Publisher:" %>
       <p><%= form.text_field :publisher%></p>
       <%= form.label :isbn, "ISBN:" %>
       <p><%= form.text_field :isbn%></p>
       <%= form.label :country_cuisine, "Nation of Origin:" %>
       <p><%= form.text_field :country_cuisine%></p>
+      <p><%= form.hidden_field :library_id, value: @user.library.id %></p>
       <%= form.submit "Submit" %>
     <% end %>
   </section>
-<% end %>

--- a/app/views/cookbooks/new.html.erb
+++ b/app/views/cookbooks/new.html.erb
@@ -1,22 +1,23 @@
 
-<% if @cookbook %>
+<% if @cookbook_check %>
   <center><h1> Is this your cookbook? </h1></center> 
   <section id="user_entries">
-    <p>Title: <%= @cookbook.title %></p>
-    <p>Author: <%= @cookbook.author %></p>
-    <p>Publisher: <%= @cookbook.publisher %></p>
-    <p>ISBN: <%= @cookbook.isbn %></p>
-    <p>Nation of Origin: <%= @cookbook.country_cuisine %></p>
+    <p>Title: <%= @cookbook_check.title %></p>
+    <p>Author: <%= @cookbook_check.author %></p>
+    <p>Publisher: <%= @cookbook_check.publisher %></p>
+    <p>ISBN: <%= @cookbook_check.isbn %></p>
+    <p>Nation of Origin: <%= @cookbook_check.country_cuisine %></p>
   </section>
 
   <section id="cookbook_match">
-    <%= form_with url: user_library_cookbooks_path(@user.id, @user.library.id), method: :post do |form| %>
+    <%= form_with model: @cookbook_check, url: user_library_cookbooks_path(@user.id, @user.library.id), method: :post do |form| %>
       <%= form.radio_button :user_entry, true %>
-      <%= form.label :user_entry, "None of the books above match, record by cookbook as entered." %>
-      <%= form.hidden_field :title, value: @cookbook.title %>
-      <%= form.hidden_field :author, value: @cookbook.author %>
-      <%= form.hidden_field :publisher, value: @cookbook.publisher%>
-      <%= form.hidden_field :country_cuisine, value: @cookbook.country_cuisine %>
+      <%= form.label :user_entry_true, "None of the books above match, record by cookbook as entered." %>
+      <%= form.hidden_field :title, value: @cookbook_check.title %>
+      <%= form.hidden_field :author, value: @cookbook_check.author %>
+      <%= form.hidden_field :publisher, value: @cookbook_check.publisher%>
+      <%= form.hidden_field :country_cuisine, value: @cookbook_check.country_cuisine %>
+      <%= form.hidden_field :library_id, value: @user.library.id %>
       <%= form.submit "Save" %>
     <% end %>
   </section>
@@ -24,7 +25,7 @@
   <center><h1> Add a New Cookbook </h1></center>
 
   <section id="cookbook_form">
-    <%= form_with url: new_user_library_cookbook_path(@user.id, @user.library.id), method: :get do |form| %>
+    <%= form_with model: @cookbook, url: new_user_library_cookbook_path(@user.id, @user.library.id), method: :get do |form| %>
       <%= form.label :title, "Title:" %>
       <p><%= form.text_field :title %></p>
       <%= form.label :author, "Author:" %>

--- a/app/views/cookbooks/new.html.erb
+++ b/app/views/cookbooks/new.html.erb
@@ -10,7 +10,7 @@
   </section>
 
   <section id="cookbook_match">
-    <%= form_with model: @cookbook_check, url: user_library_cookbooks_path(@user.id, @user.library.id), method: :post do |form| %>
+    <%= form_with model: @cookbook, url: user_library_cookbooks_path(@user.id, @user.library.id), method: :post do |form| %>
       <%= form.radio_button :user_entry, true %>
       <%= form.label :user_entry_true, "None of the books above match, record by cookbook as entered." %>
       <%= form.hidden_field :title, value: @cookbook_check.title %>

--- a/app/views/cookbooks/new.html.erb
+++ b/app/views/cookbooks/new.html.erb
@@ -14,4 +14,5 @@
       <p><%= form.hidden_field :library_id, value: @user.library.id %></p>
       <%= form.submit "Submit" %>
     <% end %>
+    <%= button_to "Cancel", user_libraries_path(@user.id), method: :get %>
   </section>

--- a/app/views/cookbooks/new.html.erb
+++ b/app/views/cookbooks/new.html.erb
@@ -4,7 +4,7 @@
       <%= form.label :title, "Title:" %>
       <p><%= form.text_field :title %></p>
       <%= form.label :author, "Author:" %>
-      <p><%= form.text_field :author, value: @cookbook.author %></p>
+      <p><%= form.text_field :author %></p>
       <%= form.label :publisher, "Publisher:" %>
       <p><%= form.text_field :publisher%></p>
       <%= form.label :isbn, "ISBN:" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,6 +2,13 @@
 <html>
   <head>
     <title>RecipeKeeper</title>
+    
+    <% flash.each do |type, msg| %>
+      <div>
+        <%= msg %>
+      </div>
+    <% end %>
+
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>

--- a/app/views/libraries/index.html.erb
+++ b/app/views/libraries/index.html.erb
@@ -2,6 +2,15 @@
 
 <h3><%= link_to 'Add a cookbook to my library', new_user_library_cookbook_path(@user.id, @user.library.id) %></h3>
 
-<% @cookbooks.each do |cookbook| %>
-  <p><%= cookbook.title %> by <%= cookbook.author %></p>
-<% end %>
+<table id="library">
+  <tr>
+    <th>Title</th>
+    <th>Author</th>
+  </tr>
+  <% @cookbooks.each do |cookbook| %>
+    <tr>
+    <td><%= cookbook.title %></td> 
+    <td><%= cookbook.author %></td>
+    </tr>
+  <% end %>
+</table>

--- a/app/views/libraries/index.html.erb
+++ b/app/views/libraries/index.html.erb
@@ -9,7 +9,7 @@
   </tr>
   <% @cookbooks.each do |cookbook| %>
     <tr>
-    <td><%= cookbook.title %></td> 
+    <td><%= link_to cookbook.title, user_library_cookbook_path(@user.id, @user.library.id, cookbook.id) %></td> 
     <td><%= cookbook.author %></td>
     </tr>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   # root "articles#index"
-  get '/', to: 'welcome#index'
+  root 'welcome#index'
   get '/auth/google_oauth2/callback', to: 'sessions#create'
 
   resources :sign_in, only: [:index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,9 @@ Rails.application.routes.draw do
   resources :sign_in, only: [:index]
   resources :users, only: [:index, :create] do
     resources :libraries, only: [:index] do
-      resources :cookbooks, only: [:new, :create] #is this too long of a route?
+      resources :cookbooks, only: [:new, :create] do #is this too long of a route?
+        get 'match', on: :new
+      end
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
   resources :sign_in, only: [:index]
   resources :users, only: [:index, :create] do
     resources :libraries, only: [:index] do
-      resources :cookbooks, only: [:new, :create] do #is this too long of a route?
+      resources :cookbooks, only: [:new, :create, :show] do #is this too long of a route?
         get 'match', on: :new
       end
     end

--- a/spec/features/cookbooks/match_spec.rb
+++ b/spec/features/cookbooks/match_spec.rb
@@ -24,8 +24,7 @@ RSpec.describe "cookbook #match" do
 
   describe "User visits the cookbook match page after submitting cookbook details in #new" do
     it "Shows the details of the cookbook submitted by the user to review 
-    and can click the radio button and submit, but the save button doesn't appear until a radio button is selected",
-    driver: :selenium_chrome, js: true do
+    and can click the radio button and submit, but the save button doesn't appear until a radio button is selected", js: true, drive: :selenium_chrome do
 
       within ("#user_entries") do
         expect(page).to have_content("Title: #{@title}")
@@ -34,15 +33,16 @@ RSpec.describe "cookbook #match" do
         expect(page).to have_content("ISBN: #{@isbn}")
         expect(page).to have_content("Nation of Origin: #{@country_cuisine}")
       end
+      
       within ("#cookbook_match") do
         expect(page).to have_button("Save", disabled: true)
-        choose :cookbook_user_entry_true
         expect(page).to_not have_field(:cookbook_title)
         expect(page).to_not have_field(:cookbook_author)
         expect(page).to_not have_field(:cookbook_publisher)
         expect(page).to_not have_field(:cookbook_country_cuisine)
+        choose :cookbook_user_entry_true
         expect(page).to have_button("Save", disabled: false)
-        click_button 'Save'
+        click_button("Save")
       end
         
       expect(page).to have_current_path(user_libraries_path(@user.id))

--- a/spec/features/cookbooks/match_spec.rb
+++ b/spec/features/cookbooks/match_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe "cookbook #match" do
 
   describe "User visits the cookbook match page after submitting cookbook details in #new" do
     it "Shows the details of the cookbook submitted by the user to review 
-        and can click the radio button and submit" do
+        and can click the radio button and submit, 
+        but the save button doesn't appear until a radio button is selected" do
         title = Faker::Book.title
         author = Faker::Book.author
         publisher = Faker::Book.publisher
@@ -35,11 +36,13 @@ RSpec.describe "cookbook #match" do
           expect(page).to have_content("Nation of Origin: #{country_cuisine}")
         end
         within ("#cookbook_match") do
+          expect(find("#save_button", visible: false)).to_not be_visible
           choose :cookbook_user_entry_true
           expect(page).to_not have_field(:cookbook_title)
           expect(page).to_not have_field(:cookbook_author)
           expect(page).to_not have_field(:cookbook_publisher)
           expect(page).to_not have_field(:cookbook_country_cuisine)
+          expect(find("#save_button", visible: true)).to_ be_visible
           click_button 'Save'
         end
         

--- a/spec/features/cookbooks/match_spec.rb
+++ b/spec/features/cookbooks/match_spec.rb
@@ -6,10 +6,10 @@ RSpec.describe "cookbook #match" do
     @library = @user.create_library
   end
 
-  describe "User visits the cookbook match page after submitting cookbook details in #new" do
+  describe "User visits the cookbook match page after submitting cookbook details in #new", js: true do
     it "Shows the details of the cookbook submitted by the user to review 
         and can click the radio button and submit, 
-        but the save button doesn't appear until a radio button is selected" do
+        but the save button doesn't appear until a radio button is selected", driver: :selenium_chrome do
         title = Faker::Book.title
         author = Faker::Book.author
         publisher = Faker::Book.publisher
@@ -26,27 +26,30 @@ RSpec.describe "cookbook #match" do
         click_button 'Submit'
       end
 
-      expect(current_path).to eq(match_new_user_library_cookbook_path(@user.id, @library.id))
+      # expect(current_path).to eq(match_new_user_library_cookbook_path(@user.id, @library.id))
 
-        within ("#user_entries") do
-          expect(page).to have_content("Title: #{title}")
-          expect(page).to have_content("Author: #{author}")
-          expect(page).to have_content("Publisher: #{publisher}")
-          expect(page).to have_content("ISBN: #{isbn}")
-          expect(page).to have_content("Nation of Origin: #{country_cuisine}")
-        end
-        within ("#cookbook_match") do
-          expect(find("#save_button", visible: false)).to_not be_visible
-          choose :cookbook_user_entry_true
-          expect(page).to_not have_field(:cookbook_title)
-          expect(page).to_not have_field(:cookbook_author)
-          expect(page).to_not have_field(:cookbook_publisher)
-          expect(page).to_not have_field(:cookbook_country_cuisine)
-          expect(find("#save_button", visible: true)).to_ be_visible
-          click_button 'Save'
-        end
+      within ("#user_entries") do
+        expect(page).to have_content("Title: #{title}")
+        expect(page).to have_content("Author: #{author}")
+        expect(page).to have_content("Publisher: #{publisher}")
+        expect(page).to have_content("ISBN: #{isbn}")
+        expect(page).to have_content("Nation of Origin: #{country_cuisine}")
+      end
+      within ("#cookbook_match") do
+        expect(page).to have_button("Save", disabled: true)
+        choose :cookbook_user_entry_true
+        expect(page).to_not have_field(:cookbook_title)
+        expect(page).to_not have_field(:cookbook_author)
+        expect(page).to_not have_field(:cookbook_publisher)
+        expect(page).to_not have_field(:cookbook_country_cuisine)
+        expect(page).to have_button("Save", disabled: false)
+        click_button 'Save'
+      end
         
-        expect(current_path).to eq(user_libraries_path(@user.id))
+      # expect(current_path).to eq(user_libraries_path(@user.id))
+      within "#library" do
+        expect(page).to have_table_row("Title" => title, "Author" => author)
+      end
     end
   end
 end

--- a/spec/features/cookbooks/match_spec.rb
+++ b/spec/features/cookbooks/match_spec.rb
@@ -26,8 +26,6 @@ RSpec.describe "cookbook #match" do
         click_button 'Submit'
       end
 
-      # expect(current_path).to eq(match_new_user_library_cookbook_path(@user.id, @library.id))
-
       within ("#user_entries") do
         expect(page).to have_content("Title: #{title}")
         expect(page).to have_content("Author: #{author}")
@@ -46,7 +44,7 @@ RSpec.describe "cookbook #match" do
         click_button 'Save'
       end
         
-      # expect(current_path).to eq(user_libraries_path(@user.id))
+      expect(page).to have_current_path(user_libraries_path(@user.id))
       within "#library" do
         expect(page).to have_table_row("Title" => title, "Author" => author)
       end

--- a/spec/features/cookbooks/match_spec.rb
+++ b/spec/features/cookbooks/match_spec.rb
@@ -4,34 +4,35 @@ RSpec.describe "cookbook #match" do
   before :each do
     @user = create(:user, :google)
     @library = @user.create_library
+
+    @title = Faker::Book.title
+    @author = Faker::Book.author
+    @publisher = Faker::Book.publisher
+    @country_cuisine = Faker::Nation.nationality
+    @isbn = Faker::Barcode.isbn
+
+    visit new_user_library_cookbook_path(@user.id, @library.id)
+    within ("#cookbook_form") do
+      fill_in :cookbook_title, with: @title
+      fill_in :cookbook_author, with: @author
+      fill_in :cookbook_publisher, with: @publisher
+      fill_in :cookbook_country_cuisine, with: @country_cuisine
+      fill_in :cookbook_isbn, with: @isbn
+      click_button 'Submit'
+    end
   end
 
-  describe "User visits the cookbook match page after submitting cookbook details in #new", js: true do
+  describe "User visits the cookbook match page after submitting cookbook details in #new" do
     it "Shows the details of the cookbook submitted by the user to review 
-        and can click the radio button and submit, 
-        but the save button doesn't appear until a radio button is selected", driver: :selenium_chrome do
-        title = Faker::Book.title
-        author = Faker::Book.author
-        publisher = Faker::Book.publisher
-        country_cuisine = Faker::Nation.nationality
-        isbn = Faker::Barcode.isbn
-
-      visit new_user_library_cookbook_path(@user.id, @library.id)
-      within ("#cookbook_form") do
-        fill_in :cookbook_title, with: title
-        fill_in :cookbook_author, with: author
-        fill_in :cookbook_publisher, with: publisher
-        fill_in :cookbook_country_cuisine, with: country_cuisine
-        fill_in :cookbook_isbn, with: isbn
-        click_button 'Submit'
-      end
+    and can click the radio button and submit, but the save button doesn't appear until a radio button is selected",
+    driver: :selenium_chrome, js: true do
 
       within ("#user_entries") do
-        expect(page).to have_content("Title: #{title}")
-        expect(page).to have_content("Author: #{author}")
-        expect(page).to have_content("Publisher: #{publisher}")
-        expect(page).to have_content("ISBN: #{isbn}")
-        expect(page).to have_content("Nation of Origin: #{country_cuisine}")
+        expect(page).to have_content("Title: #{@title}")
+        expect(page).to have_content("Author: #{@author}")
+        expect(page).to have_content("Publisher: #{@publisher}")
+        expect(page).to have_content("ISBN: #{@isbn}")
+        expect(page).to have_content("Nation of Origin: #{@country_cuisine}")
       end
       within ("#cookbook_match") do
         expect(page).to have_button("Save", disabled: true)
@@ -46,8 +47,18 @@ RSpec.describe "cookbook #match" do
         
       expect(page).to have_current_path(user_libraries_path(@user.id))
       within "#library" do
-        expect(page).to have_table_row("Title" => title, "Author" => author)
+        expect(page).to have_table_row("Title" => @title, "Author" => @author)
       end
+    end
+
+    it "User can click cancel and be redirected to the library page" do
+      expect(page).to have_button("Cancel")
+  
+      within "#cookbook_match" do
+        click_button "Cancel"
+      end
+  
+      expect(page).to have_current_path(user_libraries_path(@user.id))
     end
   end
 end

--- a/spec/features/cookbooks/match_spec.rb
+++ b/spec/features/cookbooks/match_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe "cookbook #match" do
+  before :each do
+    @user = create(:user, :google)
+    @library = @user.create_library
+  end
+
+  describe "User visits the cookbook match page after submitting cookbook details in #new" do
+    it "Shows the details of the cookbook submitted by the user to review 
+        and can click the radio button and submit" do
+        title = Faker::Book.title
+        author = Faker::Book.author
+        publisher = Faker::Book.publisher
+        country_cuisine = Faker::Nation.nationality
+        isbn = Faker::Barcode.isbn
+
+      visit new_user_library_cookbook_path(@user.id, @library.id)
+      within ("#cookbook_form") do
+        fill_in :cookbook_title, with: title
+        fill_in :cookbook_author, with: author
+        fill_in :cookbook_publisher, with: publisher
+        fill_in :cookbook_country_cuisine, with: country_cuisine
+        fill_in :cookbook_isbn, with: isbn
+        click_button 'Submit'
+      end
+
+      expect(current_path).to eq(match_new_user_library_cookbook_path(@user.id, @library.id))
+
+        within ("#user_entries") do
+          expect(page).to have_content("Title: #{title}")
+          expect(page).to have_content("Author: #{author}")
+          expect(page).to have_content("Publisher: #{publisher}")
+          expect(page).to have_content("ISBN: #{isbn}")
+          expect(page).to have_content("Nation of Origin: #{country_cuisine}")
+        end
+        within ("#cookbook_match") do
+          choose :cookbook_user_entry_true
+          expect(page).to_not have_field(:cookbook_title)
+          expect(page).to_not have_field(:cookbook_author)
+          expect(page).to_not have_field(:cookbook_publisher)
+          expect(page).to_not have_field(:cookbook_country_cuisine)
+          click_button 'Save'
+        end
+        
+        expect(current_path).to eq(user_libraries_path(@user.id))
+    end
+  end
+end

--- a/spec/features/cookbooks/new_spec.rb
+++ b/spec/features/cookbooks/new_spec.rb
@@ -76,4 +76,19 @@ RSpec.describe "New Cookbook form page" do
       expect(page).to have_field(:cookbook_title, with: "")
     end
   end
+
+  xit 'will redirect to :new and show a message when the app fails to save a cookbook' do
+    title = Faker::Book.title
+    author = Faker::Book.author
+    publisher = Faker::Book.publisher
+    country_cuisine = Faker::Nation.nationality
+    isbn = Faker::Barcode.isbn
+    library_id = nil
+    params = {title: title, author: author, publisher: publisher, country_cuisine: country_cuisine, isbn: isbn, library_id: library_id}
+
+    visit user_library_cookbooks_path(@user.id, @library.id, cookbook: params, method: :post)
+
+    expect(current_path).to eq(new_user_library_cookbook_path(@user.id, @library.id))
+    expect(page).to have_content("Something went wrong. Please re-enter your cookbook's details.")
+  end
 end

--- a/spec/features/cookbooks/new_spec.rb
+++ b/spec/features/cookbooks/new_spec.rb
@@ -63,7 +63,6 @@ RSpec.describe "New Cookbook form page" do
 
   it 'will show an error if a form is submitted without a title, 
       and anything that was populated before will be prefilled' do
-    title = Faker::Book.title
     author = Faker::Book.author
     publisher = Faker::Book.publisher
     country_cuisine = Faker::Nation.nationality
@@ -80,8 +79,8 @@ RSpec.describe "New Cookbook form page" do
     end
     
     expect(current_path).to eq(new_user_library_cookbook_path(@user.id, @library.id))
+    
     expect(page).to have_content("Please enter a title for your cookbook.")
-    save_and_open_page
     within ("#cookbook_form") do
       expect(page).to have_field(:cookbook_author, with: author)
       expect(page).to have_field(:cookbook_publisher, with: publisher)

--- a/spec/features/cookbooks/new_spec.rb
+++ b/spec/features/cookbooks/new_spec.rb
@@ -36,24 +36,11 @@ RSpec.describe "New Cookbook form page" do
       click_button 'Submit'
     end
     
-    expect(current_path).to eq(new_user_library_cookbook_path(@user.id, @library.id))
-    
-    within ("#user_entries") do
-      expect(page).to have_content("Title: #{title}")
-      expect(page).to have_content("Author: #{author}")
-      expect(page).to have_content("Publisher: #{publisher}")
-      expect(page).to have_content("ISBN: #{isbn}")
-      expect(page).to have_content("Nation of Origin: #{country_cuisine}")
-    end
     within ("#cookbook_match") do
       choose :cookbook_user_entry_true
-      expect(page).to_not have_field(:cookbook_title)
-      expect(page).to_not have_field(:cookbook_author)
-      expect(page).to_not have_field(:cookbook_publisher)
-      expect(page).to_not have_field(:cookbook_country_cuisine)
+      click_button "Save"
     end
 
-    click_button "Save"
     expect(current_path).to eq(user_libraries_path(@user.id))
 
     within "#library" do
@@ -79,8 +66,8 @@ RSpec.describe "New Cookbook form page" do
     end
     
     expect(current_path).to eq(new_user_library_cookbook_path(@user.id, @library.id))
-    
     expect(page).to have_content("Please enter a title for your cookbook.")
+    
     within ("#cookbook_form") do
       expect(page).to have_field(:cookbook_author, with: author)
       expect(page).to have_field(:cookbook_publisher, with: publisher)

--- a/spec/features/cookbooks/new_spec.rb
+++ b/spec/features/cookbooks/new_spec.rb
@@ -18,8 +18,22 @@ RSpec.describe "New Cookbook form page" do
     end
   end
 
+  it "User can click cancel and be redirected to the library page" do
+    visit new_user_library_cookbook_path(@user.id, @library.id)
+
+    expect(page).to have_button("Cancel")
+
+    within "#cookbook_form" do
+      click_button "Cancel"
+    end
+
+    expect(page).to have_current_path(user_libraries_path(@user.id))
+  end
+
   it 'can fill out and submit the form. Then the user is redirected to the match page but with matches/confirmation options
-      after clicking save, the cookbook is created and the user is redirected to the library and they can see their book listed', driver: :selenium_chrome, js: true do
+      after clicking save, the cookbook is created and the user is redirected to the library and they can see their book listed',
+      driver: :selenium_chrome, js: true do
+
     title = Faker::Book.title
     author = Faker::Book.author
     publisher = Faker::Book.publisher

--- a/spec/features/cookbooks/new_spec.rb
+++ b/spec/features/cookbooks/new_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "New Cookbook form page" do
   end
 
   it 'can fill out and submit the form. Then the user is redirected to the match page but with matches/confirmation options
-      after clicking save, the cookbook is created and the user is redirected to the library and they can see their book listed', js: true, driver: :selenium_chrome do
+      after clicking save, the cookbook is created and the user is redirected to the library and they can see their book listed', driver: :selenium_chrome, js: true do
     title = Faker::Book.title
     author = Faker::Book.author
     publisher = Faker::Book.publisher
@@ -41,7 +41,7 @@ RSpec.describe "New Cookbook form page" do
       click_button "Save"
     end
 
-    # expect(current_path).to eq(user_libraries_path(@user.id))
+    expect(page).to have_current_path(user_libraries_path(@user.id))
 
     within "#library" do
       expect(page).to have_table_row("Title" => title, "Author" => author)

--- a/spec/features/cookbooks/new_spec.rb
+++ b/spec/features/cookbooks/new_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "New Cookbook form page" do
 
   it 'can fill out and submit the form. Then the user is redirected to the match page but with matches/confirmation options
       after clicking save, the cookbook is created and the user is redirected to the library and they can see their book listed',
-      driver: :selenium_chrome, js: true do
+      js: true do
 
     title = Faker::Book.title
     author = Faker::Book.author

--- a/spec/features/cookbooks/new_spec.rb
+++ b/spec/features/cookbooks/new_spec.rb
@@ -11,10 +11,10 @@ RSpec.describe "New Cookbook form page" do
     
     expect(page).to have_content("Add a New Cookbook")
     within ("#cookbook_form") do
-      expect(page).to have_field(:title)
-      expect(page).to have_field(:author)
-      expect(page).to have_field(:publisher)
-      expect(page).to have_field(:country_cuisine)
+      expect(page).to have_field(:cookbook_title)
+      expect(page).to have_field(:cookbook_author)
+      expect(page).to have_field(:cookbook_publisher)
+      expect(page).to have_field(:cookbook_country_cuisine)
     end
   end
 
@@ -28,11 +28,11 @@ RSpec.describe "New Cookbook form page" do
 
     visit new_user_library_cookbook_path(@user.id, @library.id)
     within ("#cookbook_form") do
-      fill_in :title, with: title
-      fill_in :author, with: author
-      fill_in :publisher, with: publisher
-      fill_in :country_cuisine, with: country_cuisine
-      fill_in :isbn, with: isbn
+      fill_in :cookbook_title, with: title
+      fill_in :cookbook_author, with: author
+      fill_in :cookbook_publisher, with: publisher
+      fill_in :cookbook_country_cuisine, with: country_cuisine
+      fill_in :cookbook_isbn, with: isbn
       click_button 'Submit'
     end
     
@@ -45,18 +45,48 @@ RSpec.describe "New Cookbook form page" do
       expect(page).to have_content("ISBN: #{isbn}")
       expect(page).to have_content("Nation of Origin: #{country_cuisine}")
     end
-
-      expect(page).to_not have_field(:title)
-      expect(page).to_not have_field(:author)
-      expect(page).to_not have_field(:publisher)
-      expect(page).to_not have_field(:country_cuisine)
+    within ("#cookbook_match") do
+      choose :cookbook_user_entry_true
+      expect(page).to_not have_field(:cookbook_title)
+      expect(page).to_not have_field(:cookbook_author)
+      expect(page).to_not have_field(:cookbook_publisher)
+      expect(page).to_not have_field(:cookbook_country_cuisine)
+    end
 
     click_button "Save"
     expect(current_path).to eq(user_libraries_path(@user.id))
 
-    expect(page).to have_content("#{title} by #{author}")
+    within "#library" do
+      expect(page).to have_table_row("Title" => title, "Author" => author)
+    end
   end
 
-  # it 'will show an error if a form is submitted without a title'
+  it 'will show an error if a form is submitted without a title, 
+      and anything that was populated before will be prefilled' do
+    title = Faker::Book.title
+    author = Faker::Book.author
+    publisher = Faker::Book.publisher
+    country_cuisine = Faker::Nation.nationality
+    isbn = Faker::Barcode.isbn
 
+    visit new_user_library_cookbook_path(@user.id, @library.id)
+    
+    within ("#cookbook_form") do
+      fill_in :cookbook_author, with: author
+      fill_in :cookbook_publisher, with: publisher
+      fill_in :cookbook_country_cuisine, with: country_cuisine
+      fill_in :cookbook_isbn, with: isbn
+      click_button 'Submit'
+    end
+    
+    expect(current_path).to eq(new_user_library_cookbook_path(@user.id, @library.id))
+    expect(page).to have_content("Please enter a title for your cookbook.")
+    save_and_open_page
+    within ("#cookbook_form") do
+      expect(page).to have_field(:cookbook_author, with: author)
+      expect(page).to have_field(:cookbook_publisher, with: publisher)
+      expect(page).to have_field(:cookbook_country_cuisine, with: country_cuisine)
+      expect(page).to have_field(:cookbook_isbn, with: isbn)
+    end
+  end
 end

--- a/spec/features/cookbooks/new_spec.rb
+++ b/spec/features/cookbooks/new_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe "New Cookbook form page" do
     end
   end
 
-  it 'can fill out and submit the form then page is redirected to the same page but with matches/confirmation options
-      after clicking save, the cookbook is created and the user is redirected to the library and they can see their book listed' do
+  it 'can fill out and submit the form. Then the user is redirected to the match page but with matches/confirmation options
+      after clicking save, the cookbook is created and the user is redirected to the library and they can see their book listed', js: true, driver: :selenium_chrome do
     title = Faker::Book.title
     author = Faker::Book.author
     publisher = Faker::Book.publisher
@@ -41,7 +41,7 @@ RSpec.describe "New Cookbook form page" do
       click_button "Save"
     end
 
-    expect(current_path).to eq(user_libraries_path(@user.id))
+    # expect(current_path).to eq(user_libraries_path(@user.id))
 
     within "#library" do
       expect(page).to have_table_row("Title" => title, "Author" => author)

--- a/spec/features/cookbooks/new_spec.rb
+++ b/spec/features/cookbooks/new_spec.rb
@@ -73,6 +73,7 @@ RSpec.describe "New Cookbook form page" do
       expect(page).to have_field(:cookbook_publisher, with: publisher)
       expect(page).to have_field(:cookbook_country_cuisine, with: country_cuisine)
       expect(page).to have_field(:cookbook_isbn, with: isbn)
+      expect(page).to have_field(:cookbook_title, with: "")
     end
   end
 end

--- a/spec/features/libraries/index_spec.rb
+++ b/spec/features/libraries/index_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'library index' do
   end
 
   describe 'visiting a users library' do
-    it 'shows a users library page with names library at the top' do
+    it 'shows a users library page with [names] library at the top' do
       visit user_libraries_path(@user.id)
    
       expect(page).to have_content("#{@user.first_name}'s Library")
@@ -19,7 +19,7 @@ RSpec.describe 'library index' do
       expect(page).to have_link("Add a cookbook to my library", href: new_user_library_cookbook_path(@user.id, @library.id))
     end
 
-    it 'shows books in my library' do
+    it 'shows books in my library and books are listed as a table' do
       book1 = create(:cookbook, library: @library)
       book2 = create(:cookbook, library: @library)
       book3 = create(:cookbook, library: @library)
@@ -27,14 +27,15 @@ RSpec.describe 'library index' do
       book5 = create(:cookbook, library: @library)
 
       visit user_libraries_path(@user.id)
-
-      expect(page).to have_content("#{book1.title} by #{book1.author}")
-      expect(page).to have_content("#{book2.title} by #{book2.author}")
-      expect(page).to have_content("#{book3.title} by #{book3.author}")
-      expect(page).to have_content("#{book4.title} by #{book4.author}")
-      expect(page).to have_content("#{book5.title} by #{book5.author}")
+      
+      within "#library" do
+        expect(page).to have_table_row("Title" => book1.title, "Author" => book1.author)
+        expect(page).to have_table_row("Title" => book2.title, "Author" => book2.author)
+        expect(page).to have_table_row("Title" => book3.title, "Author" => book3.author)
+        expect(page).to have_table_row("Title" => book4.title, "Author" => book4.author)
+        expect(page).to have_table_row("Title" => book5.title, "Author" => book5.author)
+        expect(page).to_not have_table_row("Title" => "be the dream", "Author" => "bob")
+      end
     end
-
-    it 'books are listed in a table'
   end
 end

--- a/spec/features/libraries/index_spec.rb
+++ b/spec/features/libraries/index_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'library index' do
       expect(page).to have_link("Add a cookbook to my library", href: new_user_library_cookbook_path(@user.id, @library.id))
     end
 
-    it 'shows books in my library and books are listed as a table' do
+    it 'shows books in my library and books are listed as a table and each is a link to the book show page' do
       book1 = create(:cookbook, library: @library)
       book2 = create(:cookbook, library: @library)
       book3 = create(:cookbook, library: @library)
@@ -30,10 +30,15 @@ RSpec.describe 'library index' do
       
       within "#library" do
         expect(page).to have_table_row("Title" => book1.title, "Author" => book1.author)
+        expect(page).to have_link(book1.title, href: user_library_cookbook_path(@user.id, @library.id, book1.id))
         expect(page).to have_table_row("Title" => book2.title, "Author" => book2.author)
+        expect(page).to have_link(book2.title, href: user_library_cookbook_path(@user.id, @library.id, book2.id))
         expect(page).to have_table_row("Title" => book3.title, "Author" => book3.author)
+        expect(page).to have_link(book3.title, href: user_library_cookbook_path(@user.id, @library.id, book3.id))
         expect(page).to have_table_row("Title" => book4.title, "Author" => book4.author)
+        expect(page).to have_link(book4.title, href: user_library_cookbook_path(@user.id, @library.id, book4.id))
         expect(page).to have_table_row("Title" => book5.title, "Author" => book5.author)
+        expect(page).to have_link(book5.title, href: user_library_cookbook_path(@user.id, @library.id, book5.id))
         expect(page).to_not have_table_row("Title" => "be the dream", "Author" => "bob")
       end
     end

--- a/spec/features/libraries/index_spec.rb
+++ b/spec/features/libraries/index_spec.rb
@@ -34,5 +34,7 @@ RSpec.describe 'library index' do
       expect(page).to have_content("#{book4.title} by #{book4.author}")
       expect(page).to have_content("#{book5.title} by #{book5.author}")
     end
+
+    it 'books are listed in a table'
   end
 end

--- a/spec/models/cookbook_spec.rb
+++ b/spec/models/cookbook_spec.rb
@@ -3,8 +3,6 @@ require 'rails_helper'
 RSpec.describe Cookbook, type: :model do
   describe 'validations' do
     it {should validate_presence_of :title}
-    it {should validate_presence_of :author}
-    it {should validate_presence_of :publisher}
   end
 
   describe 'relationships' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,6 +8,17 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 require 'capybara/rails'
+require 'selenium-webdriver'
+
+Capybara.register_driver :selenium_chrome do |app|
+  options = Selenium::WebDriver::Chrome::Options.new
+  options.add_argument('--headless') # Run Chrome in headless mode
+  options.add_argument('--disable-gpu') # Disable GPU for headless mode to work
+
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+end
+
+Capybara.javascript_driver = :selenium_chrome
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,7 @@ SimpleCov.start do
 end
 require 'webmock/rspec'
 require 'capybara/rspec'
+require "capybara_table/rspec"
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,9 +17,10 @@ SimpleCov.start do
   add_filter "/spec/spec_helper.rb"
   add_filter "/spec/rails_helper.rb"
 end
-require 'webmock/rspec'
+# require 'webmock/rspec'
 require 'capybara/rspec'
 require "capybara_table/rspec"
+require 'selenium/webdriver'
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate


### PR DESCRIPTION
This PR:

Adds gems:
- capybara-table
- selenium-webdriver

Updates rubyonrails.yml workflow to install both chrome and chromedriver

Creates a cookbook match page for the user to verify the info updated and (in a future feature) choose if the cookbook entered matches one that is populated by an API.

Adds a js script
- Creates a function where the 'save' button in `cookbook match page` is disabled until a radio button is chosen.

Adds a cancel button to both `cookbook new` and `cookbook match`