### PR TITLE
Adds condition for when authors is nil

### DIFF
--- a/app/views/cookbooks/edit.html.slim
+++ b/app/views/cookbooks/edit.html.slim
@@ -11,7 +11,7 @@ html
         = form.label :title, "Subtitle:" 
         p = form.text_field :subtitle, value: @cookbook.subtitle
         = form.label :authors, "Author:" 
-        p = form.text_field :authors, multiple: true, value: @cookbook.authors.to_sentence
+        p = form.text_field :authors, multiple: true, value: !@cookbook.authors.nil? ? @cookbook.authors.to_sentence : ""
         = form.label :publisher, "Publisher:" 
         p = form.text_field :publisher, value: @cookbook.publisher
         = form.label :published_date, "Published Year:"

--- a/spec/features/cookbooks/edit_spec.rb
+++ b/spec/features/cookbooks/edit_spec.rb
@@ -24,6 +24,16 @@ RSpec.describe "Edit Cookbook Page" do
       end
     end
 
+    it "If authors is nil, the text field is blank" do
+      @cookbook.update!(authors: nil)
+
+      visit edit_user_library_cookbook_path(@user.id, @user.library.id, @cookbook.id)
+
+      within "#edit_#{@cookbook.id}" do
+        expect(page).to have_field(:cookbook_authors, with: "")
+      end
+    end
+
     it "The form updates the cookbook info after clicking submit" do
       visit edit_user_library_cookbook_path(@user.id, @user.library.id, @cookbook.id)
 


### PR DESCRIPTION
Fixes edit form to display authors as blank when it's kept as `nil` in table.